### PR TITLE
Use long open tags

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,4 +1,4 @@
-<? 
+<?php
 
   $root            = $_SERVER["DOCUMENT_ROOT"]; 
   $location        = urldecode($_SERVER["REQUEST_URI"]);
@@ -127,7 +127,7 @@
 <td align="right" class="headerfont"><b>Size</b></td>
 </tr>
 
-<?
+<?php
 
   // Show "README.html" if it exists
   if ( file_exists($readme = join_paths($path, "README.html")) ) {


### PR DESCRIPTION
This allows to run on servers that disable "short_open_tags", which also
is the default for the production php.ini since some versions

https://github.com/php/php-src/commit/c3fcaf1d7d1f663080a7c14c0e561077e44229ae
https://github.com/php/php-src/blob/80b6a13553791962120580c9f3e87f039ba4c2a8/php.ini-production#L202
